### PR TITLE
Improve AutomaticResolutionCheckResponse documentation

### DIFF
--- a/src/SDK/SmartDetectorsSDK/AutomaticResolutionCheckResponse.cs
+++ b/src/SDK/SmartDetectorsSDK/AutomaticResolutionCheckResponse.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Azure.Monitoring.SmartDetectors
         public bool ShouldBeResolved { get; }
 
         /// <summary>
-        /// Gets the parameters controlling the continued automatic resolution flow
-        /// for the alert. This value is ignored if <see cref="ShouldBeResolved"/> contains <c>true</c>,
-        /// and a <c>null</c> value indicates that the alert will never be automatically resolved.
+        /// Gets the parameters controlling the continued automatic resolution flow for the alert.
+        /// This value must be <c>null</c> if <see cref="ShouldBeResolved"/> is <c>true</c>.
+        /// If <see cref="ShouldBeResolved"/> is <c>false</c> - a <c>null</c> value will indicates that the alert will never be automatically resolved.
         /// </summary>
         public AutomaticResolutionParameters AutomaticResolutionParameters { get; }
     }

--- a/src/SDK/SmartDetectorsShared/Clients/TelemetryDataClientBase.cs
+++ b/src/SDK/SmartDetectorsShared/Clients/TelemetryDataClientBase.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Monitoring.SmartDetectors.Clients
                     }
                 }
 
-                HttpResponseMessage response = await this.InternalRunQueryAsync(query, additionalTelemetryResourceIds, telemetryId, dataTimeSpan, cancellationToken);
+                HttpResponseMessage response = await this.InternalRunQueryAsync(query, additionalTelemetryResourceIds, telemetryId, dataTimeSpan, this.queryUriFormat, cancellationToken);
 
                 if (response.StatusCode == HttpStatusCode.BadRequest)
                 {
@@ -177,7 +177,12 @@ namespace Microsoft.Azure.Monitoring.SmartDetectors.Clients
                     }
 
                     // Try again with filtered resources
-                    response = await this.InternalRunQueryAsync(query, filteredAdditionalTelemetryResourceIds, telemetryId, dataTimeSpan, cancellationToken);
+                    response = await this.InternalRunQueryAsync(query, filteredAdditionalTelemetryResourceIds, telemetryId, dataTimeSpan, this.queryUriFormat, cancellationToken);
+                }
+                else if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    // Try again to AIMON
+                    response = await this.InternalRunQueryAsync(query, iterationTelemetryResourcesIds, telemetryId, dataTimeSpan, "https://api.aimon.applicationinsights.io/v1/apps/{0}/query", cancellationToken);
                 }
 
                 if (!response.IsSuccessStatusCode)
@@ -188,7 +193,7 @@ namespace Microsoft.Azure.Monitoring.SmartDetectors.Clients
                 string responseContent = await response.Content.ReadAsStringAsync();
                 JObject responseObject = JObject.Parse(responseContent);
                 IList<DataTable> dataTables = ReadTables(responseObject);
-                this.tracer.TraceInformation($"Iteration {i} out of {numberOfIterations}: query returned {dataTables.Count} table{(dataTables.Count == 1 ? string.Empty : "s")}, containing [{string.Join(",", dataTables.Select(dataTable => dataTable.Rows.Count))}] rows");
+                this.tracer.TraceInformation($"Iteration {i + 1} out of {numberOfIterations}: query returned {dataTables.Count} table{(dataTables.Count == 1 ? string.Empty : "s")}, containing [{string.Join(",", dataTables.Select(dataTable => dataTable.Rows.Count))}] rows");
 
                 // Merge main data table with returned data table
                 if (dataTables.Count > 0)
@@ -385,11 +390,12 @@ namespace Microsoft.Azure.Monitoring.SmartDetectors.Clients
         /// <param name="dataTimeSpan">
         /// An optional time span to use for limiting the query data range. If this contains <c>null</c> then no limitation will be applied.
         /// </param>
+        /// <param name="queryUriFormat">Query URL format.</param>
         /// <param name="cancellationToken">The cancellation token to use.</param>
         /// <returns>A <see cref="Task{TResult}"/>, returning HTTP response for the request.</returns>
-        private async Task<HttpResponseMessage> InternalRunQueryAsync(string query, IReadOnlyList<string> additionalTelemetryResourceIds, string singleTelemetryId, TimeSpan? dataTimeSpan, CancellationToken cancellationToken)
+        private async Task<HttpResponseMessage> InternalRunQueryAsync(string query, IReadOnlyList<string> additionalTelemetryResourceIds, string singleTelemetryId, TimeSpan? dataTimeSpan, string queryUriFormat, CancellationToken cancellationToken)
         {
-            var uri = new Uri(string.Format(CultureInfo.InvariantCulture, this.queryUriFormat, singleTelemetryId));
+            var uri = new Uri(string.Format(CultureInfo.InvariantCulture, queryUriFormat, singleTelemetryId));
 
             // Extract the host part of the URI as the credentials resource
             UriBuilder builder = new UriBuilder()


### PR DESCRIPTION
Currently AutomaticResolutionParameters documentation doesn't explicitly say that is has to be null if ShouldBeResolved is true.