### PR TITLE
Change MetricChart.ResourceId to string

### DIFF
--- a/src/SDK/SmartDetectors.Extensions/AlertExtensions.cs
+++ b/src/SDK/SmartDetectors.Extensions/AlertExtensions.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.Monitoring.SmartDetectors.Extensions
                 metricChart.TimeGrain,
                 ConvertAggregationTypeToContractsAggregationType(metricChart.AggregationType))
             {
-                ResourceId = metricChart.ResourceId.ToResourceId(),
+                ResourceId = metricChart.ResourceId,
                 MetricNamespace = metricChart.MetricNamespace,
                 MetricDimensions = new Dictionary<string, string>(metricChart.MetricDimensions),
                 StartTimeUtc = metricChart.StartTimeUtc,

--- a/src/SDK/SmartDetectorsExtensionsPackage/SmartDetectorsExtensionsPackage.nuproj
+++ b/src/SDK/SmartDetectorsExtensionsPackage/SmartDetectorsExtensionsPackage.nuproj
@@ -23,7 +23,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>Microsoft.Azure.Monitoring.SmartDetectors.Extensions</Id>
-    <Version>1.0.14.1</Version>
+    <Version>1.0.15.0</Version>
     <Title>Azure Smart Detectors Extensions</Title>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft Corporation</Owners>

--- a/src/SDK/SmartDetectorsPackage/SmartDetectorsPackage.nuproj
+++ b/src/SDK/SmartDetectorsPackage/SmartDetectorsPackage.nuproj
@@ -22,7 +22,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>Microsoft.Azure.Monitoring.SmartDetectors</Id>
-    <Version>1.0.14.2</Version>
+    <Version>1.0.15.0</Version>
     <Title>Azure Smart Detectors</Title>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft Corporation</Owners>

--- a/src/SDK/SmartDetectorsSDK/AlertPresentation/MetricChart.cs
+++ b/src/SDK/SmartDetectorsSDK/AlertPresentation/MetricChart.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Monitoring.SmartDetectors.AlertPresentation
         /// Gets or sets an optional resource ID to query for the metric. If this is <c>null</c> or empty,
         /// then the chart will display the metric from the alert's <see cref="Alert.ResourceIdentifier"/>.
         /// </summary>
-        public ResourceIdentifier ResourceId { get; set; }
+        public string ResourceId { get; set; }
 
         /// <summary>
         /// Gets the name of the metric to display in the chart.

--- a/src/SDK/SmartDetectorsSDK/AlertPresentation/MetricChart.cs
+++ b/src/SDK/SmartDetectorsSDK/AlertPresentation/MetricChart.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Monitoring.SmartDetectors.AlertPresentation
 
         /// <summary>
         /// Gets or sets an optional resource ID to query for the metric. If this is <c>null</c> or empty,
-        /// then the chart will display the metric from the alert's <see cref="Alert.ResourceIdentifier"/>.
+        /// then the chart will display the metric from the alert's resource.
         /// </summary>
         public string ResourceId { get; set; }
 

--- a/test/SDK/SmartDetectorsExtensionsTests/AlertPresentation/MetricChartPropertyAttributeTests.cs
+++ b/test/SDK/SmartDetectorsExtensionsTests/AlertPresentation/MetricChartPropertyAttributeTests.cs
@@ -62,7 +62,7 @@ namespace SmartDetectorsExtensionsTests.AlertPresentation
             [MetricChartProperty("MetricChartDisplayName", Order = 8)]
             public MetricChart MetricChart => new MetricChart("someMetric", TimeSpan.FromHours(1), AggregationType.Average)
             {
-                ResourceId = default(ResourceIdentifier),
+                ResourceId = string.Empty,
                 MetricNamespace = "namespace",
                 MetricDimensions =
                 {

--- a/test/SDK/SmartDetectorsExtensionsTests/AlertPresentation/MetricChartPropertyAttributeTests.cs
+++ b/test/SDK/SmartDetectorsExtensionsTests/AlertPresentation/MetricChartPropertyAttributeTests.cs
@@ -31,7 +31,7 @@ namespace SmartDetectorsExtensionsTests.AlertPresentation
             Assert.AreEqual(1, contractsAlert.AlertProperties.Count);
 
             MetricChartAlertProperty alertProperty = (MetricChartAlertProperty)contractsAlert.AlertProperties[0];
-            Assert.AreEqual(default(ResourceIdentifier).ToResourceId(), alertProperty.ResourceId);
+            Assert.AreEqual(string.Empty, alertProperty.ResourceId);
             Assert.AreEqual("someMetric", alertProperty.MetricName);
             Assert.AreEqual("namespace", alertProperty.MetricNamespace);
             Assert.AreEqual(2, alertProperty.MetricDimensions.Count);


### PR DESCRIPTION
To add more flexibility to the user when specifying the resource (for example, create the ID with ToResourceId(StorageServiceType))